### PR TITLE
Change to use own implementation of supervisor spec

### DIFF
--- a/lib/pool_sup.ex
+++ b/lib/pool_sup.ex
@@ -206,8 +206,8 @@ defmodule PoolSup do
 
   defp supervisor_init_arg(mod, init_arg, opts) do
     sup_name    = opts[:name] || :self
-    worker_spec = {mod, [init_arg]}
-    spec        = S.init([worker_spec], [strategy: :simple_one_for_one, max_restarts: 0, max_seconds: 1])
+    worker_spec = %{id: mod, start: {mod, :start_link, [init_arg]}, restart: :temporary}
+    spec        = H.make_sup_spec([worker_spec], [max_restarts: 0, max_seconds: 1])
     {sup_name, Callback, [spec]}
   end
 

--- a/lib/pool_sup/custom_sup_helper.ex
+++ b/lib/pool_sup/custom_sup_helper.ex
@@ -4,6 +4,9 @@ defmodule PoolSup.CustomSupHelper do
   @moduledoc false
 
   @type sup_state :: term
+  @type init_option ::
+          {:max_restarts , non_neg_integer}
+          | {:max_seconds, pos_integer    }
 
   #
   # common gen_server callbacks
@@ -55,6 +58,13 @@ defmodule PoolSup.CustomSupHelper do
 
   defun gen_server_opts(opts :: Keyword.t(any)) :: [name: GenServer.name] do
     Enum.filter(opts, &match?({:name, _}, &1))
+  end
+
+  defun make_sup_spec(worker_spec :: [Supervisor.child_spec], opts :: [init_option] \\ []) :: {:ok, tuple} do
+    intensity = Keyword.get(opts, :max_restarts, 3)
+    period    = Keyword.get(opts, :max_seconds , 5)
+    flags     = %{strategy: :simple_one_for_one, intensity: intensity, period: period}
+    {:ok, {flags, worker_spec}}
   end
 
   defun start_child(sup_state :: sup_state, extra :: [term] \\ []) :: {pid, sup_state} do

--- a/lib/pool_sup/multi.ex
+++ b/lib/pool_sup/multi.ex
@@ -260,8 +260,8 @@ defmodule PoolSup.Multi do
 
   defp supervisor_init_arg(worker_module, worker_init_arg, opts) do
     sup_name    = opts[:name] || :self
-    worker_spec = {PoolSup, [worker_module, worker_init_arg]}
-    spec        = S.init([worker_spec], [strategy: :simple_one_for_one])
+    worker_spec = PoolSup.child_spec([worker_module, worker_init_arg])
+    spec        = H.make_sup_spec([worker_spec])
     {sup_name, PoolSup.Callback, [spec]}
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,14 +11,6 @@ defmodule W do
     {:ok, args}
   end
 
-  def child_spec(args) do
-    %{
-      id:      __MODULE__,
-      start:   {__MODULE__, :start_link, args},
-      restart: :temporary,
-    }
-  end
-
   def start_link(_) do
     GenServer.start_link(__MODULE__, {}, [])
   end


### PR DESCRIPTION
- Consider only `:simple_one_for_one` for supervisor strategy
- Change to not call worker's `child_spec/1` in `PoolSup`